### PR TITLE
Metadata Inconsistencies

### DIFF
--- a/App/Models/VectorDB.cs
+++ b/App/Models/VectorDB.cs
@@ -3,31 +3,6 @@ using System.Text.Json.Serialization;
 
 namespace Rift.App.Models;
 
-// Document metadata for oceanographic data
-public class DocumentMetadata
-{
-    [JsonPropertyName("source")]
-    public string Source { get; set; } = string.Empty;
-
-    [JsonPropertyName("data_type")]
-    public string DataType { get; set; } = string.Empty; // e.g., "sensor_data", "location_info", "instrument_spec"
-
-    [JsonPropertyName("timestamp")]
-    public string? Timestamp { get; set; }
-
-    [JsonPropertyName("location")]
-    public string? Location { get; set; }
-
-    [JsonPropertyName("depth")]
-    public double? Depth { get; set; }
-
-    [JsonPropertyName("instrument_type")]
-    public string? InstrumentType { get; set; }
-
-    [JsonPropertyName("tags")]
-    public string? Tags { get; set; }
-}
-
 // Single document model
 public class Document
 {
@@ -38,7 +13,7 @@ public class Document
     public string Text { get; set; } = string.Empty;
 
     [JsonPropertyName("metadata")]
-    public DocumentMetadata? Metadata { get; set; }
+    public Dictionary<string, object>? Metadata { get; set; }
 }
 
 // Request models
@@ -306,71 +281,6 @@ public class RelevantDocument
     public string Id { get; set; } = string.Empty;
     public string Content { get; set; } = string.Empty;
     public double Relevance { get; set; }
-    public DocumentMetadata? Metadata { get; set; }
+    public Dictionary<string, object>? Metadata { get; set; }
     public string Source { get; set; } = string.Empty;
-}
-
-// Filtering helpers for oceanographic data
-public static class VectorDBFilters
-{
-    public static Dictionary<string, object> ByDataType(string dataType)
-    {
-        return new Dictionary<string, object>
-        {
-            ["data_type"] = dataType
-        };
-    }
-
-    public static Dictionary<string, object> ByLocation(string location)
-    {
-        return new Dictionary<string, object>
-        {
-            ["location"] = location
-        };
-    }
-
-    public static Dictionary<string, object> ByInstrumentType(string instrumentType)
-    {
-        return new Dictionary<string, object>
-        {
-            ["instrument_type"] = instrumentType
-        };
-    }
-
-    public static Dictionary<string, object> ByDepthRange(double minDepth, double maxDepth)
-    {
-        return new Dictionary<string, object>
-        {
-            ["depth"] = new Dictionary<string, object>
-            {
-                ["$gte"] = minDepth,
-                ["$lte"] = maxDepth
-            }
-        };
-    }
-
-    public static Dictionary<string, object> ByDateRange(DateTime startDate, DateTime endDate)
-    {
-        return new Dictionary<string, object>
-        {
-            ["timestamp"] = new Dictionary<string, object>
-            {
-                ["$gte"] = startDate.ToString("yyyy-MM-ddTHH:mm:ssZ"),
-                ["$lte"] = endDate.ToString("yyyy-MM-ddTHH:mm:ssZ")
-            }
-        };
-    }
-
-    public static Dictionary<string, object> CombineFilters(params Dictionary<string, object>[] filters)
-    {
-        var combined = new Dictionary<string, object>();
-        foreach (var filter in filters)
-        {
-            foreach (var kvp in filter)
-            {
-                combined[kvp.Key] = kvp.Value;
-            }
-        }
-        return combined;
-    }
 }

--- a/ChromaDB/src/main.py
+++ b/ChromaDB/src/main.py
@@ -47,19 +47,10 @@ embedding_function = embedding_functions.SentenceTransformerEmbeddingFunction(
     model_name="all-MiniLM-L6-v2"  # Good balance of performance and speed for scientific text
 )
 
-class DocumentMetadata(BaseModel):
-    source: str
-    data_type: str  # e.g., "sensor_data", "location_info", "instrument_spec"
-    timestamp: Optional[str] = None
-    location: Optional[str] = None
-    depth: Optional[float] = None
-    instrument_type: Optional[str] = None
-    tags: Optional[str] = None  # Comma-separated string of tags instead of List[str]
-
 class Document(BaseModel):
     id: str
     text: str
-    metadata: Optional[DocumentMetadata] = None
+    metadata: Optional[Dict[str, Any]] = None
 
 class BatchDocuments(BaseModel):
     documents: List[Document]
@@ -445,7 +436,8 @@ async def semantic_query(request: SemanticQueryRequest):
         filtered_results = {
             "documents": [[]],
             "metadatas": [[]],
-            "distances": [[]]
+            "distances": [[]],
+            "ids": [[]]
         }
 
         if result["documents"] and result["documents"][0]:
@@ -463,6 +455,7 @@ async def semantic_query(request: SemanticQueryRequest):
                     filtered_results["documents"][0].append(result["documents"][0][i])
                     filtered_results["metadatas"][0].append(result["metadatas"][0][i] if result["metadatas"] else None)
                     filtered_results["distances"][0].append(distance)
+                    filtered_results["ids"][0].append(result["ids"][0][i] if "ids" in result and result["ids"] else None)
                     logger.debug(f"Document {i}: distance={distance:.4f}, similarity={similarity:.4f}, threshold={effective_threshold:.4f}")
 
         return {


### PR DESCRIPTION
Addresses Issue #178 
## PR justification
There were some initial boilerplate metadata class declarations and usages that were not consistent with the current metadata structure which caused issues. Also the document ids were not being retrieved when calling the query/semantic endpoint in the ChromaDB server. 

## Changes
- Removed definitions and usages of DocumentMetadata class
- Replaced by simply using the metadata from the json response (much more maintainable)
- Passed document ids to address the "doc_{chunk_number}" fallback bug